### PR TITLE
Remove cleanup on disconnect

### DIFF
--- a/nmcli-rofi
+++ b/nmcli-rofi
@@ -148,7 +148,6 @@ function main () {
 
     elif [[ "$OPS" =~ 'Disconnect' ]]; then
       nmcli con down uuid $CURRUUID
-      cleanup_networks
 
     elif [[ "$OPS" =~ 'Manual' ]]; then
       # Manual entry of the SSID


### PR DESCRIPTION
The networks were removed on disconnect, without any notice, which is
not a desired behavior in most cases.

Fixes #4